### PR TITLE
Add dependency on dynamixel_msg package

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,17 +6,21 @@ The ivaEdy package has dependency on a ros package named dynamixel_motor. There 
 
 ## Usage
 go to `~/YOUR/ROS_WORKING_SPACE`
-```
+
+```bash
 cd src/
 git clone https://github.com/ivaROS/ivaEdy.git
+git clone https://github.com/ivaROS/ivaDynamixel.git
 cd ..
 catkin_make
 ```
+
 Note: you may see error when generating cmakelist, please install any missing packages according to the error messages. 
 
-ex. you will need `dynamixel_motor`
-```
-git clone https://github.com/arebgun/dynamixel_motor.git
+ex. you will need [`dynamixel_motor`](https://github.com/ivaROS/ivaDynamixel)
+
+```bash
+git clone https://github.com/ivaROS/ivaDynamixel.git
 ```
 
 ## package 

--- a/edy_dualarm_control/CMakeLists.txt
+++ b/edy_dualarm_control/CMakeLists.txt
@@ -13,7 +13,6 @@ install(DIRECTORY config DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
 install(DIRECTORY script DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
 
 install(
-  PROGRAMS
-    scripts/disable_torque_edy.py
+  PROGRAMS script/disable_torque_edy.py
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )

--- a/edy_dualarm_experiment/CMakeLists.txt
+++ b/edy_dualarm_experiment/CMakeLists.txt
@@ -3,14 +3,15 @@ project(edy_dualarm_experiment)
 
 SET(CMAKE_CXX_FLAGS "-std=c++0x")
 
-find_package(catkin REQUIRED COMPONENTS moveit_core moveit_ros_planning moveit_ros_planning_interface pluginlib cmake_modules)
+find_package(catkin REQUIRED COMPONENTS dynamixel_msgs moveit_core moveit_ros_planning moveit_ros_planning_interface pluginlib cmake_modules)
 
 find_package(Boost REQUIRED system filesystem date_time thread)
 
 catkin_package(
 #  INCLUDE_DIRS include
 #  LIBRARIES pr2_moveit_tutorials
-  CATKIN_DEPENDS 
+  CATKIN_DEPENDS
+    dynamixel_msgs
     moveit_core
     moveit_ros_planning_interface
     interactive_markers

--- a/edy_dualarm_experiment/package.xml
+++ b/edy_dualarm_experiment/package.xml
@@ -15,6 +15,7 @@
   <build_depend>moveit_ros_planning_interface</build_depend>
   <build_depend>moveit_ros_perception</build_depend>
   <build_depend>interactive_markers</build_depend>
+  <build_depend>dynamixel_msgs</build_depend>
   <build_depend>cmake_modules</build_depend>
 
   <run_depend>pluginlib</run_depend>
@@ -22,6 +23,7 @@
   <run_depend>moveit_fake_controller_manager</run_depend>
   <run_depend>moveit_ros_planning_interface</run_depend>
   <run_depend>moveit_ros_perception</run_depend>
+  <run_depend>dynamixel_msgs</run_depend>
   <run_depend>interactive_markers</run_depend>
 
 </package>

--- a/edy_singlearm_control/CMakeLists.txt
+++ b/edy_singlearm_control/CMakeLists.txt
@@ -13,7 +13,6 @@ install(DIRECTORY config DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
 install(DIRECTORY script DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
 
 install(
-  PROGRAMS
-    scripts/disable_torque_edy.py
+  PROGRAMS script/disable_torque_edy.py
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )


### PR DESCRIPTION
I get the following error when running `catkin build` with a workspace that also includes [ivaDynamixel](https://github.com/ivaROS/ivaDynamixel):

```bash
Errors     << edy_dualarm_experiment:make /home/anthony/robotics/autobots/logs/edy_dualarm_experiment/build.make.014.log
/home/anthony/robotics/autobots/src/ivaEdy/edy_dualarm_experiment/pickplace/src/pick.cpp:46:10: fatal error: dynamixel_msgs/JointState.h: No such file or directory
   46 | #include <dynamixel_msgs/JointState.h>
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
make[2]: *** [pickplace/CMakeFiles/pick.dir/build.make:76: pickplace/CMakeFiles/pick.dir/src/pick.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:2642: pickplace/CMakeFiles/pick.dir/all] Error 2
make: *** [Makefile:146: all] Error 2
```

Adding the dependency fixes the build issue.